### PR TITLE
POC: Adding disabling of mods in start-setupModpack

### DIFF
--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -6,6 +6,7 @@ set -e -o pipefail
 : "${MODS:=}"
 : "${MODS_OUT_DIR:=/data/mods}"
 : "${MODS_FILE:=}"
+: "${DISABLED_MODS:=}"
 : "${PLUGINS:=}"
 : "${PLUGINS_OUT_DIR:=/data/plugins}"
 : "${PLUGINS_FILE:=}"
@@ -155,6 +156,7 @@ function handleGenericPacks() {
   : "${GENERIC_PACKS:=${GENERIC_PACK}}"
   : "${GENERIC_PACKS_PREFIX:=}"
   : "${GENERIC_PACKS_SUFFIX:=}"
+  : "${DISABLED_MODS:=${DISABLED_MODS}}"
 
   if [[ "${GENERIC_PACKS}" ]]; then
     IFS=',' read -ra packs <<< "${GENERIC_PACKS}"
@@ -190,6 +192,12 @@ function handleGenericPacks() {
       for pack in "${packFiles[@]}"; do
         isDebugging && ls -l "${pack}"
         extract "${pack}" "${base_dir}"
+      done
+
+      # Disable mods
+      for mod in ${DISABLED_MODS}; do
+	log Disabling $mod
+	find "${base_dir}" -name "$mod" -exec mv {} {}.DISABLED -v \;
       done
 
       # Remove any eula file since container manages it

--- a/scripts/start-setupModpack
+++ b/scripts/start-setupModpack
@@ -6,7 +6,7 @@ set -e -o pipefail
 : "${MODS:=}"
 : "${MODS_OUT_DIR:=/data/mods}"
 : "${MODS_FILE:=}"
-: "${DISABLED_MODS:=}"
+: "${DISABLE_MODS:=}"
 : "${PLUGINS:=}"
 : "${PLUGINS_OUT_DIR:=/data/plugins}"
 : "${PLUGINS_FILE:=}"
@@ -156,7 +156,7 @@ function handleGenericPacks() {
   : "${GENERIC_PACKS:=${GENERIC_PACK}}"
   : "${GENERIC_PACKS_PREFIX:=}"
   : "${GENERIC_PACKS_SUFFIX:=}"
-  : "${DISABLED_MODS:=${DISABLED_MODS}}"
+  : "${DISABLE_MODS:=${DISABLE_MODS}}"
 
   if [[ "${GENERIC_PACKS}" ]]; then
     IFS=',' read -ra packs <<< "${GENERIC_PACKS}"
@@ -195,7 +195,7 @@ function handleGenericPacks() {
       done
 
       # Disable mods
-      for mod in ${DISABLED_MODS}; do
+      for mod in ${DISABLE_MODS}; do
 	log Disabling $mod
 	find "${base_dir}" -name "$mod" -exec mv {} {}.DISABLED -v \;
       done


### PR DESCRIPTION
Adding feature to disable specific mods in generic modpacks.

Example of usage below for GTNH 2.7.2 w/ Crucible where `lwjgl3ify-2.1.5.jar` and `archaicfix-0.7.4.jar` need to be disabled.
```
  mc-server:
    image: itzg/minecraft-server:java21
    tty: true
    stdin_open: true
    restart: unless-stopped
    environment:
      DEBUG: true
      TYPE: CRUCIBLE
      VERSION: 1.7.10
      CRUCIBLE_RELEASE: staging-8ae5051
      GENERIC_PACKS: GT_New_Horizons_2.7.2_Server_Java_17-21
      GENERIC_PACKS_SUFFIX: .zip
      GENERIC_PACKS_PREFIX: https://downloads.gtnewhorizons.com/ServerPacks/
      DISABLED_MODS: |
        lwjgl3ify-2.1.5.jar
        archaicfix-0.7.4.jar
      ENABLE_QUERY: true
      EULA: TRUE
      MEMORY: 8G
      JVM_OPTS: -Dfml.readTimeout=180 @java9args.txt
    ports:
      - '25565:25565'
    volumes:
      - ./mc-server/server:/data
```